### PR TITLE
fix(aws.CredentialsConfig): update dependencies and code to use AccountsConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the plugin will perform a sync with remote host to provide needed account (if fo
 3. Supports IAM authentication when used with API Gateway. The Spinnaker managing account role must have the permission to invoke configured API gateway.   
 
 ### Requirements
-1. Must be used with Spinnaker version 1.24 or higher.
+1. Must be used with Spinnaker version 1.28 or higher.
 2. Must enable [AWS support](https://docs.armory.io/docs/armory-admin/aws/add-aws-account/)
 3. Must enable [Lambda support](https://kb.armory.io/s/article/AWS-Lambda-Custom-Webhook-Stages).
 4. Must enable [ECS support](https://spinnaker.io/setup/install/providers/aws/aws-ecs/#clouddriver-yaml-properties)

--- a/account-registration/account-registration.gradle
+++ b/account-registration/account-registration.gradle
@@ -1,4 +1,3 @@
-
 apply plugin: "io.spinnaker.plugin.service-extension"
 apply plugin: 'java'
 apply plugin: "groovy"
@@ -21,45 +20,46 @@ spinnakerPlugin {
   requires = "clouddriver>=7.1.0"
 }
 
-
 dependencies {
-  implementation "com.google.guava:guava:30.0-jre"
-  compileOnly "org.codehaus.groovy:groovy-all:+"
-  compileOnly (group: 'org.springframework', name: 'spring-context', version: '5.2.9.RELEASE')
-  compileOnly (group: 'io.spinnaker.kork', name: 'kork-plugins-spring-api', version: "${korkVersion}")
-  compileOnly (group: 'org.springframework', name: 'spring-web', version: '5.2.9.RELEASE')
-  compileOnly "io.spinnaker.clouddriver:clouddriver-api:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:clouddriver-aws:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:clouddriver-ecs:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:clouddriver-lambda:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:cats-core:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:clouddriver-security:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:clouddriver-eureka:${clouddriverVersion}"
-  compileOnly "io.spinnaker.clouddriver:clouddriver-core:${clouddriverVersion}"
-  compileOnly "io.spinnaker.fiat:fiat-core:${fiatVersion}"
-  compileOnly 'com.amazonaws:aws-java-sdk:1.11.802'
-  compileOnly 'org.projectlombok:lombok:+'
-  compileOnly 'com.amazonaws:aws-java-sdk-core:1.11.1009'
-  annotationProcessor "org.projectlombok:lombok:+"
-  annotationProcessor("org.pf4j:pf4j:$pf4jVersion")
+  implementation(enforcedPlatform("io.spinnaker.clouddriver:clouddriver-bom:${clouddriverVersion}"))
+  implementation "com.google.guava:guava"
+  compileOnly "org.codehaus.groovy:groovy-all"
+  compileOnly (group: 'org.springframework', name: 'spring-context')
+  compileOnly (group: 'io.spinnaker.kork', name: 'kork-plugins-spring-api')
+  compileOnly (group: 'org.springframework', name: 'spring-web')
+  compileOnly "io.spinnaker.clouddriver:clouddriver-api"
+  compileOnly "io.spinnaker.clouddriver:clouddriver-aws"
+  compileOnly "io.spinnaker.clouddriver:clouddriver-ecs"
+  compileOnly "io.spinnaker.clouddriver:clouddriver-lambda"
+  compileOnly "io.spinnaker.clouddriver:cats-core"
+  compileOnly "io.spinnaker.clouddriver:clouddriver-security"
+  compileOnly "io.spinnaker.clouddriver:clouddriver-eureka"
+  compileOnly "io.spinnaker.clouddriver:clouddriver-core"
+  compileOnly "io.spinnaker.fiat:fiat-core"
+  compileOnly 'com.amazonaws:aws-java-sdk'
+  compileOnly 'org.projectlombok:lombok'
+  compileOnly 'com.amazonaws:aws-java-sdk-core'
+  compileOnly "org.codehaus.groovy:groovy"
 
-  testImplementation "io.spinnaker.clouddriver:clouddriver-api:${clouddriverVersion}"
-  testImplementation "io.spinnaker.clouddriver:clouddriver-aws:${clouddriverVersion}"
-  testImplementation "io.spinnaker.clouddriver:clouddriver-ecs:${clouddriverVersion}"
-  testImplementation "io.spinnaker.clouddriver:cats-core:${clouddriverVersion}"
-  testImplementation "io.spinnaker.clouddriver:clouddriver-security:${clouddriverVersion}"
-  testImplementation "io.spinnaker.clouddriver:clouddriver-eureka:${clouddriverVersion}"
-  testImplementation "io.spinnaker.clouddriver:clouddriver-core:${clouddriverVersion}"
-  testImplementation "io.spinnaker.fiat:fiat-core:${fiatVersion}"
-  testImplementation group: 'io.strikt', name: 'strikt-core', version: '0.22.1'
-  testImplementation group: 'dev.minutest', name: 'minutest', version: '1.10.0'
-  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.2.5.RELEASE'
-  testImplementation group: 'org.springframework', name: 'spring-web', version: '5.2.9.RELEASE'
-  testImplementation 'com.amazonaws:aws-java-sdk-core:1.11.802'
-  compile "org.codehaus.groovy:groovy:2.5.13"
-  testCompile platform("org.spockframework:spock-bom:2.0-M3-groovy-2.5")
+  annotationProcessor(platform("io.spinnaker.clouddriver:clouddriver-bom:${clouddriverVersion}"))
+  annotationProcessor "org.projectlombok:lombok"
+  annotationProcessor("org.pf4j:pf4j")
+
+  testImplementation "io.spinnaker.clouddriver:clouddriver-api"
+  testImplementation "io.spinnaker.clouddriver:clouddriver-aws"
+  testImplementation "io.spinnaker.clouddriver:clouddriver-ecs"
+  testImplementation "io.spinnaker.clouddriver:cats-core"
+  testImplementation "io.spinnaker.clouddriver:clouddriver-security"
+  testImplementation "io.spinnaker.clouddriver:clouddriver-eureka"
+  testImplementation "io.spinnaker.clouddriver:clouddriver-core"
+  testImplementation "io.spinnaker.fiat:fiat-core"
+  testImplementation group: 'io.strikt', name: 'strikt-core'
+  testImplementation group: 'dev.minutest', name: 'minutest'
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+  testImplementation group: 'org.springframework', name: 'spring-web'
+  testImplementation 'com.amazonaws:aws-java-sdk-core'
+  testCompile "org.codehaus.groovy:groovy"
   testCompile "org.spockframework:spock-core"
-
 }
 
 test {

--- a/account-registration/src/main/java/com/amazon/aws/spinnaker/plugin/registration/AwsCredentialsDefinitionSource.java
+++ b/account-registration/src/main/java/com/amazon/aws/spinnaker/plugin/registration/AwsCredentialsDefinitionSource.java
@@ -1,27 +1,27 @@
 package com.amazon.aws.spinnaker.plugin.registration;
 
 import com.google.common.collect.ImmutableList;
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig;
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration;
 import com.netflix.spinnaker.credentials.definition.CredentialsDefinitionSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
-public class AwsCredentialsDefinitionSource implements CredentialsDefinitionSource<CredentialsConfig.Account> {
+public class AwsCredentialsDefinitionSource implements CredentialsDefinitionSource<AccountsConfiguration.Account> {
     private final AccountsStatus accountsStatus;
-    private final CredentialsConfig credentialsConfig;
-    private List<CredentialsConfig.Account> awsCredentialsDefinitions;
+    private final AccountsConfiguration accountsConfiguration;
+    private List<AccountsConfiguration.Account> awsCredentialsDefinitions;
 
     @Autowired
-    AwsCredentialsDefinitionSource(AccountsStatus accountsStatus, CredentialsConfig credentialsConfig) {
+    AwsCredentialsDefinitionSource(AccountsStatus accountsStatus, AccountsConfiguration accountsConfiguration) {
         this.accountsStatus = accountsStatus;
-        this.credentialsConfig = credentialsConfig;
+        this.accountsConfiguration = accountsConfiguration;
     }
 
     @Override
-    public List<CredentialsConfig.Account> getCredentialsDefinitions() {
+    public List<AccountsConfiguration.Account> getCredentialsDefinitions() {
         if (awsCredentialsDefinitions == null) {
-            awsCredentialsDefinitions = credentialsConfig.getAccounts();
+            awsCredentialsDefinitions = accountsConfiguration.getAccounts();
         }
         if (accountsStatus.getDesiredAccounts()) {
             awsCredentialsDefinitions = accountsStatus.getEC2AccountsAsList();

--- a/account-registration/src/test/groovy/com/amazon/aws/spinnaker/plugin/registration/AccountsStatusSpec.groovy
+++ b/account-registration/src/test/groovy/com/amazon/aws/spinnaker/plugin/registration/AccountsStatusSpec.groovy
@@ -1,5 +1,6 @@
 package com.amazon.aws.spinnaker.plugin.registration
 
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration
 import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
 import com.netflix.spinnaker.clouddriver.ecs.security.ECSCredentialsConfig
 import org.springframework.http.ResponseEntity
@@ -15,9 +16,9 @@ class AccountsStatusSpec extends Specification {
 
     RestTemplate mockRest = Mock(RestTemplate)
 
-    CredentialsConfig credentialsConfig = new CredentialsConfig() {{
+    AccountsConfiguration accountsConfiguration = new AccountsConfiguration() {{
         setAccounts([
-            new CredentialsConfig.Account() {{
+            new AccountsConfiguration.Account() {{
                 name = "test1"
                 accountId = "1"
                 assumeRole = "role/role1"
@@ -25,7 +26,7 @@ class AccountsStatusSpec extends Specification {
                 lambdaEnabled = false
                 enabled = true
             }},
-            new CredentialsConfig.Account() {{
+            new AccountsConfiguration.Account() {{
                 name = "test9"
                 accountId = "9"
                 assumeRole = "role/role9"
@@ -33,7 +34,7 @@ class AccountsStatusSpec extends Specification {
                 lambdaEnabled = true
                 enabled = true
             }},
-            new CredentialsConfig.Account() {{
+            new AccountsConfiguration.Account() {{
                 name = "test20"
                 accountId = "20"
                 assumeRole = "role/role20"
@@ -55,9 +56,11 @@ class AccountsStatusSpec extends Specification {
         ])
     }}
 
+    CredentialsConfig credentialsConfig = new CredentialsConfig()
+
     def "no accounts should be returned"() {
         given:
-        AccountsStatus status = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus status = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
         }}
 
@@ -72,7 +75,7 @@ class AccountsStatusSpec extends Specification {
 
     def "accounts should be overwritten"() {
         given:
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
             nextTry = Instant.ofEpochSecond(0L)
@@ -105,7 +108,7 @@ class AccountsStatusSpec extends Specification {
     }
     def "it should call next URL"() {
         given:
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
         }}
@@ -154,7 +157,7 @@ class AccountsStatusSpec extends Specification {
 
     def "it should remove empty provider accounts"() {
         given:
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
         }}
@@ -187,7 +190,7 @@ class AccountsStatusSpec extends Specification {
 
     def "it should remove one account only after initial sync"() {
         given:
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
         }}
@@ -243,7 +246,7 @@ class AccountsStatusSpec extends Specification {
 
     def "it should update one account only after initial sync"() {
         given:
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig,"http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
         }}
@@ -299,7 +302,7 @@ class AccountsStatusSpec extends Specification {
 
     def "it should add one account only after initial sync"() {
         given:
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello/", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
         }}
@@ -349,7 +352,7 @@ class AccountsStatusSpec extends Specification {
         given:
         credentialsConfig.setAccessKeyId("access")
         credentialsConfig.setSecretAccessKey("secret")
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello?env=test&tag=test", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello?env=test&tag=test", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
             iamAuth = true
@@ -382,7 +385,7 @@ class AccountsStatusSpec extends Specification {
         given:
         credentialsConfig.setAccessKeyId("access")
         credentialsConfig.setSecretAccessKey("secret")
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello?env=test", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello?env=test", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
             iamAuth = true
@@ -402,7 +405,7 @@ class AccountsStatusSpec extends Specification {
         given:
         credentialsConfig.setAccessKeyId("access")
         credentialsConfig.setSecretAccessKey("secret")
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello?env=test", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello?env=test", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
             iamAuth = true
@@ -439,7 +442,7 @@ class AccountsStatusSpec extends Specification {
         given:
         credentialsConfig.setAccessKeyId("access")
         credentialsConfig.setSecretAccessKey("secret")
-        AccountsStatus accountsStatus = new AccountsStatus(credentialsConfig, "http://localhost:8080/hello?env=test", 0L, 0L) {{
+        AccountsStatus accountsStatus = new AccountsStatus(accountsConfiguration, credentialsConfig, "http://localhost:8080/hello?env=test", 0L, 0L) {{
             restTemplate = mockRest
             setECSCredentialsConfig(ecsConfig)
             iamAuth = true

--- a/account-registration/src/test/groovy/com/amazon/aws/spinnaker/plugin/registration/AwsCredentialsDefinitionSourceSpec.groovy
+++ b/account-registration/src/test/groovy/com/amazon/aws/spinnaker/plugin/registration/AwsCredentialsDefinitionSourceSpec.groovy
@@ -1,37 +1,37 @@
 package com.amazon.aws.spinnaker.plugin.registration
 
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
 import spock.lang.Specification
+import com.netflix.spinnaker.clouddriver.aws.security.config.AccountsConfiguration
 
 class AwsCredentialsDefinitionSourceSpec extends Specification {
     def accountsStatus = Mock(AccountsStatus)
-    def credentialsConfig = Mock(CredentialsConfig)
+    def accountsConfiguration = Mock(AccountsConfiguration)
 
     def 'should check remote'() {
         given:
-        def definitionSource = new AwsCredentialsDefinitionSource(accountsStatus, credentialsConfig)
+        def definitionSource = new AwsCredentialsDefinitionSource(accountsStatus, accountsConfiguration)
 
         when:
         def definitions = definitionSource.getCredentialsDefinitions()
 
         then:
-        1 * credentialsConfig.getAccounts() >> [Mock(CredentialsConfig.Account)]
+        1 * accountsConfiguration.getAccounts() >> [Mock(AccountsConfiguration.Account)]
         1 * accountsStatus.getDesiredAccounts() >> true
-        1 * accountsStatus.getEC2AccountsAsList() >> [Mock(CredentialsConfig.Account), Mock(CredentialsConfig.Account)]
+        1 * accountsStatus.getEC2AccountsAsList() >> [Mock(AccountsConfiguration.Account), Mock(AccountsConfiguration.Account)]
         definitions.size() == 2
     }
 
     def 'should not check remote'() {
         given:
-        def definitionSource = new AwsCredentialsDefinitionSource(accountsStatus, credentialsConfig)
+        def definitionSource = new AwsCredentialsDefinitionSource(accountsStatus, accountsConfiguration)
 
         when:
         def definitions = definitionSource.getCredentialsDefinitions()
 
         then:
-        1 * credentialsConfig.getAccounts() >> [Mock(CredentialsConfig.Account)]
+        1 * accountsConfiguration.getAccounts() >> [Mock(AccountsConfiguration.Account)]
         1 * accountsStatus.getDesiredAccounts() >> false
-        0 * accountsStatus.getEC2AccountsAsList() >> [Mock(CredentialsConfig.Account), Mock(CredentialsConfig.Account)]
+        0 * accountsStatus.getEC2AccountsAsList() >> [Mock(AccountsConfiguration.Account), Mock(AccountsConfiguration.Account)]
         definitions.size() == 1
     }
 }

--- a/account-registration/src/test/groovy/com/amazon/aws/spinnaker/plugin/registration/EcsCredentialsDefinitionSourceSpec.groovy
+++ b/account-registration/src/test/groovy/com/amazon/aws/spinnaker/plugin/registration/EcsCredentialsDefinitionSourceSpec.groovy
@@ -5,17 +5,17 @@ import spock.lang.Specification
 
 class EcsCredentialsDefinitionSourceSpec extends Specification {
     def accountsStatus = Mock(AccountsStatus)
-    def credentialsConfig = Mock(ECSCredentialsConfig)
+    def accountsConfiguration = Mock(ECSCredentialsConfig)
 
     def 'should return definitions'() {
         given:
-        def definitionSource = new EcsCredentialsDefinitionSource(accountsStatus, credentialsConfig)
+        def definitionSource = new EcsCredentialsDefinitionSource(accountsStatus, accountsConfiguration)
 
         when:
         def definitions = definitionSource.getCredentialsDefinitions()
 
         then:
-        0 * credentialsConfig.getAccounts() >> [Mock(ECSCredentialsConfig.Account)]
+        0 * accountsConfiguration.getAccounts() >> [Mock(ECSCredentialsConfig.Account)]
         0 * accountsStatus.getDesiredAccounts() >> true
         1 * accountsStatus.getECSAccountsAsList() >> [Mock(ECSCredentialsConfig.Account), Mock(ECSCredentialsConfig.Account)]
         definitions.size() == 2
@@ -23,27 +23,27 @@ class EcsCredentialsDefinitionSourceSpec extends Specification {
 
     def 'should return definitions when remote host is down on startup' () {
         given:
-        def definitionSource = new EcsCredentialsDefinitionSource(accountsStatus, credentialsConfig)
+        def definitionSource = new EcsCredentialsDefinitionSource(accountsStatus, accountsConfiguration)
 
         when:
         def definitions = definitionSource.getCredentialsDefinitions()
 
         then:
-        1 * credentialsConfig.getAccounts() >> [Mock(ECSCredentialsConfig.Account)]
+        1 * accountsConfiguration.getAccounts() >> [Mock(ECSCredentialsConfig.Account)]
         1 * accountsStatus.getECSAccountsAsList() >> []
         definitions.size() == 1
     }
 
     def 'should return definitions when remote host is down on startup but second call succeeds' () {
         given:
-        def definitionSource = new EcsCredentialsDefinitionSource(accountsStatus, credentialsConfig)
+        def definitionSource = new EcsCredentialsDefinitionSource(accountsStatus, accountsConfiguration)
 
         when:
         def definitionStartup = definitionSource.getCredentialsDefinitions()
         def definitions = definitionSource.getCredentialsDefinitions()
 
         then:
-        1 * credentialsConfig.getAccounts() >> [Mock(ECSCredentialsConfig.Account)]
+        1 * accountsConfiguration.getAccounts() >> [Mock(ECSCredentialsConfig.Account)]
         2 * accountsStatus.getECSAccountsAsList() >>> [ [], [Mock(ECSCredentialsConfig.Account), Mock(ECSCredentialsConfig.Account)]]
         definitionStartup.size() == 1
         definitions.size() == 2

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ version=1.2.0
 spinnakerGradleVersion=8.12.0
 pf4jVersion=3.2.0
 korkVersion=7.110.0
-clouddriverVersion=5.74.0
+clouddriverVersion=5.76.1
 fiatVersion=1.28.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,3 @@
-pluginManagement {
-  repositories {
-    mavenLocal()
-    maven { url "https://dl.bintray.com/spinnaker/gradle/" }
-    gradlePluginPortal()
-  }
-}
-
 rootProject.name="aws-account-registration-plugin-spinnaker"
 
 include "account-registration"


### PR DESCRIPTION
Hi, while trying to deploy the plugin using the latest version of clouddriver we got the following error:

```Error creating bean with name 'amazonCredentialsLoader' defined in class path resource [com/netflix/spinnaker/clouddriver/aws/security/AmazonCredentialsInitializer.class]: Unexpected exception during bean creation; nested exception is java.lang.TypeNotPresentException: Type com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig$Account not present```

That's because this commit has some refactoring and moved the Accounts out of the CredentialsConfig class: https://github.com/spinnaker/clouddriver/commit/b820dd1d753f5e0ada8d005abb30fd08b7ca7c65


To fix that we did the following:
* Cleanup of unused imports + blank lines on account-registration.gradle
* Update to use the latest version of clouddriver-bom
* Update to use the AccountsConfiguration instead of CredentialsConfig